### PR TITLE
Simplify printable report layout

### DIFF
--- a/relatorios-ultra-vite/src/index.css
+++ b/relatorios-ultra-vite/src/index.css
@@ -35,26 +35,153 @@ body {
 .no-export { }
 .print-block { page-break-inside: avoid; }
 .print-page  { background: var(--bg) !important; }
-.report-header { text-align:center; margin-bottom: 1rem; }
-.report-logos { display:flex; align-items:center; justify-content:center; gap:.75rem; margin-bottom:.5rem; }
-.report-logos img { height:40px; width:auto; object-fit:contain; border:1px solid var(--border); border-radius:.375rem; background:#fff; }
-.report-title { font-size: clamp(1.25rem, 2.5vw, 1.75rem); font-weight:700; line-height:1.25; margin:0; }
-.report-subtitle { color: var(--muted); font-size:.875rem; margin-top:.25rem; }
-.card { background: var(--bg); border: 1px solid var(--border); border-radius: 1rem; box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 1rem; }
+.card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
+  padding: 1.25rem;
+}
 .card + .card { margin-top: 1rem; }
-.table-wrap { overflow: auto; }
-.table { width:100%; border-collapse:collapse; font-size:.875rem; background:#fff; }
-.table thead tr { border-bottom:1px solid var(--border); }
-.table th, .table td { padding:.5rem .5rem; vertical-align: top; }
-.table td.right, .table th.right { text-align: right; }
-.table tr + tr { border-top: 1px solid #f4f4f5; }
-.tr-strong { font-weight: 600; }
+
+.report-paper {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 2rem 2.25rem;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+.report-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 1.5rem;
+}
+.report-title {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.3vw, 1.8rem);
+  font-weight: 700;
+  color: var(--text);
+}
+.report-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.2rem;
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+.report-meta span:first-child {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.report-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.report-section-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.report-observations-text {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fcfcfd;
+  padding: 1rem 1.25rem;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--text);
+}
+.report-observations-text p {
+  margin: 0;
+}
+.report-observations-text p + p {
+  margin-top: 0.75rem;
+}
+
+.report-table-wrapper {
+  overflow-x: auto;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fff;
+}
+.report-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+.report-table thead {
+  background: #f6f6f6;
+}
+.report-table th {
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+}
+.report-table td {
+  padding: 0.85rem 1rem;
+  border-top: 1px solid var(--border);
+  vertical-align: top;
+}
+.report-table .right { text-align: right; }
+.report-table tbody tr.is-equivalence {
+  background: #f9fafb;
+  font-weight: 600;
+}
+.report-table tbody tr.is-total {
+  background: #f1f5f9;
+  font-weight: 700;
+}
+
+.report-empty {
+  font-size: 0.85rem;
+  color: var(--muted);
+  padding: 0.85rem 1rem;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+.report-footer {
+  font-size: 0.75rem;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+}
+
+@media (max-width: 900px) {
+  .report-paper {
+    padding: 1.5rem;
+  }
+  .report-meta {
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+}
 
 @media print{
   .no-print, .no-print * { display:none !important; }
   @page { size: A4 portrait; margin: 12mm 10mm; }
   body { background:#fff !important; color:#000 !important; }
-  .print-block, .report-header, .card, .table-wrap, table { page-break-inside: avoid; }
-  .table thead tr { border-bottom-color:#cfcfd4; }
-  .table tr + tr { border-top-color:#eaeaee; }
+  .print-block, .report-paper, .report-section, .report-table-wrapper, .report-header { page-break-inside: avoid; }
+  .report-paper { box-shadow: none; border: none; padding: 0; }
+  .card { box-shadow: none; }
+  .report-table-wrapper { border-color: #d4d4d8; }
+  .report-table thead { background: #f1f5f9 !important; }
+  .report-table tbody tr.is-total { background: #e2e8f0 !important; }
 }


### PR DESCRIPTION
## Summary
- streamline the printable report with a compact header plus observations, daily exams, equivalences, and consolidated tables
- derive clinic headline text, formatted observation lines, and equivalence rows to feed the simplified sections
- refresh the report styling for a cleaner card, table, and print presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e30d4928f0832c8341d218e2d72d71