### PR TITLE
Update printable report footer message

### DIFF
--- a/relatorios-ultra-vite/src/App.tsx
+++ b/relatorios-ultra-vite/src/App.tsx
@@ -354,8 +354,9 @@ export default function App() {
           </div>
         </Card>
 
-        <footer className="text-xs text-zinc-500">
-          * Equivalências fixas: Obstétrico de rotina → 1× Abdominal total; Morfológico 1º → 1× Abdominal total + 1× Rins e Vias; Morfológico 2º → 1× Abdominal total + 1× Rins e Vias + 1× Transvaginal; Mamas/Mamas e Axilas → 2× Rins e Vias.
+        <footer className="report-footer text-xs text-zinc-500 space-y-1">
+          <p>Relatório Gerado pelo Sistema de  Gerenciamento e Laudos Automatizados LILI ® - Laudos Inteligentes - desenvolvido por Dr. Andrew Costa (c) 2025.</p>
+          <p>* Equivalências fixas: Obstétrico de rotina → 1× Abdominal total; Morfológico 1º → 1× Abdominal total + 1× Rins e Vias; Morfológico 2º → 1× Abdominal total + 1× Rins e Vias + 1× Transvaginal; Mamas/Mamas e Axilas → 2× Rins e Vias.</p>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update the printable report footer to show the new LILI attribution sentence
- keep the equivalence legend in the footer while adopting the report-footer class

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e32dd3c008832caa338452def38b8c