### PR TITLE
Improve printable report layout and metadata blocks

### DIFF
--- a/relatorios-ultra-vite/src/App.tsx
+++ b/relatorios-ultra-vite/src/App.tsx
@@ -248,6 +248,10 @@ export default function App() {
       .filter((part) => part && part.length > 0) as string[];
     return parts.join(" • ");
   }, [currentClinic]);
+  const clinicName = currentClinic?.name ?? "Unidade não informada";
+  const clinicPlace = currentClinic?.place ?? "—";
+  const clinicCity = currentClinic?.city ?? "—";
+  const attendanceDateLabel = filterDate ? fmtBRDate(filterDate) : "—";
   const generatedAtLabel = useMemo(() => generatedAt.toLocaleDateString("pt-BR"), [generatedAt]);
   const observationLines = useMemo(
     () => observationEntries.map((obs) => `${obs.label}${obs.qty > 1 ? ` (${obs.qty}×)` : ""}: ${obs.obs}`),
@@ -320,14 +324,47 @@ export default function App() {
         </div>
         <div className="report-paper print-block" ref={printRef}>
           <header className="report-header">
-            <h1 className="report-title">Relatório de procedimentos (ultrassonografias) — Dr. Andrew Costa</h1>
-            <div className="report-meta">
-              <span>{clinicLine || "Unidade não informada"}</span>
-              <span>Data do atendimento: {filterDate ? fmtBRDate(filterDate) : "—"}</span>
-              <span>Relatório emitido em: {generatedAtLabel}</span>
-              <span>Total de exames: {examsCount}</span>
-              <span>Valor convertido: {BRL(fromCents(grandTotal))}</span>
+            <div className="report-header-top">
+              <div>
+                <p className="report-pretitle">Dr. Andrew Costa</p>
+                <h1 className="report-title">Relatório de procedimentos (ultrassonografias)</h1>
+                <p className="report-subtitle">
+                  {clinicLine || "Unidade não informada"}
+                </p>
+              </div>
+              <div className="report-date-box">
+                <span className="label">Data do atendimento</span>
+                <span className="value">{attendanceDateLabel}</span>
+              </div>
             </div>
+            <div className="report-stats">
+              <div className="report-stat">
+                <span className="label">Total de exames</span>
+                <span className="value">{examsCount}</span>
+              </div>
+              <div className="report-stat">
+                <span className="label">Valor convertido</span>
+                <span className="value">{BRL(fromCents(grandTotal))}</span>
+              </div>
+            </div>
+            <dl className="report-meta-grid">
+              <div className="report-meta-item">
+                <dt>Unidade</dt>
+                <dd>{clinicName}</dd>
+              </div>
+              <div className="report-meta-item">
+                <dt>Local</dt>
+                <dd>{clinicPlace}</dd>
+              </div>
+              <div className="report-meta-item">
+                <dt>Município</dt>
+                <dd>{clinicCity}</dd>
+              </div>
+              <div className="report-meta-item">
+                <dt>Relatório emitido</dt>
+                <dd>{generatedAtLabel}</dd>
+              </div>
+            </dl>
           </header>
 
           <section className="report-section">

--- a/relatorios-ultra-vite/src/index.css
+++ b/relatorios-ultra-vite/src/index.css
@@ -61,22 +61,104 @@ body {
   border-bottom: 1px solid var(--border);
   padding-bottom: 1.5rem;
 }
+.report-header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+.report-pretitle {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--muted);
+}
 .report-title {
   margin: 0;
   font-size: clamp(1.4rem, 2.3vw, 1.8rem);
   font-weight: 700;
   color: var(--text);
 }
-.report-meta {
+.report-subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  max-width: 36rem;
+}
+.report-date-box {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem 1.2rem;
-  font-size: 0.88rem;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: #f6f7fb;
+  text-align: right;
+  min-width: 12rem;
+}
+.report-date-box .label {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
   color: var(--muted);
 }
-.report-meta span:first-child {
+.report-date-box .value {
+  font-size: 1.15rem;
+  font-weight: 700;
   color: var(--text);
+}
+.report-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 0.75rem;
+}
+.report-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fbfbfb;
+}
+.report-stat .label {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.report-stat .value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text);
+}
+.report-meta-grid {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+.report-meta-item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 0.75rem 1rem;
+}
+.report-meta-item dt {
+  margin: 0;
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.report-meta-item dd {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
   font-weight: 600;
+  color: var(--text);
 }
 
 .report-section {
@@ -168,9 +250,13 @@ body {
   .report-paper {
     padding: 1.5rem;
   }
-  .report-meta {
+  .report-header-top {
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 1rem;
+  }
+  .report-date-box {
+    align-self: stretch;
+    text-align: left;
   }
 }
 
@@ -181,6 +267,7 @@ body {
   .print-block, .report-paper, .report-section, .report-table-wrapper, .report-header { page-break-inside: avoid; }
   .report-paper { box-shadow: none; border: none; padding: 0; }
   .card { box-shadow: none; }
+  .report-date-box, .report-stat { background: #fff !important; }
   .report-table-wrapper { border-color: #d4d4d8; }
   .report-table thead { background: #f1f5f9 !important; }
   .report-table tbody tr.is-total { background: #e2e8f0 !important; }


### PR DESCRIPTION
## Summary
- restructure the printable report header with a highlighted date badge and summary blocks for totals
- add dedicated styles for metadata cards so the exported PDF and print view have clearer hierarchy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3c5ba4268832c9abed2ee29e46303