### PR TITLE
Add consolidated PDF export option

### DIFF
--- a/src/assets/dr-andrew-costa-logo.svg
+++ b/src/assets/dr-andrew-costa-logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Logomarca Dr. Andrew Costa</title>
+  <desc id="desc">Três linhas douradas formando um monograma com o nome Dr. Andrew Costa e o slogan Ultrassonografia é Arte.</desc>
+  <defs>
+    <linearGradient id="gold" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#e9d3a0" />
+      <stop offset="100%" stop-color="#c9a15a" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="#ffffff" rx="48" ry="48" />
+  <g fill="none" stroke="url(#gold)" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" transform="translate(76 40)">
+    <path d="M180 32L0 392" />
+    <path d="M180 32l180 360" />
+    <path d="M98 216l82-184 82 184" />
+  </g>
+  <text x="256" y="398" font-size="52" font-family="'Playfair Display','Times New Roman',serif" text-anchor="middle" fill="#1f2937" letter-spacing="4">
+    DR. ANDREW COSTA
+  </text>
+  <text x="256" y="450" font-size="32" font-family="'Allura','Great Vibes','Pacifico',cursive" text-anchor="middle" fill="#1f2937">
+    Ultrassonografia é Arte.
+  </text>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -4,9 +4,9 @@
 
 @page { size: A4; margin: 12mm 10mm; }
 html,body,#root{height:100%}
-body{color:#0a0a0a;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
+body{color:#0a0a0a;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-size:.9rem}
 
-.report-paper{width:100%;max-width:800px;margin:24px auto;background:#fff;border:1px solid #e4e4e7;border-radius:16px;box-shadow:0 10px 24px rgba(0,0,0,.06);padding:20px}
+.report-paper{width:100%;max-width:800px;margin:24px auto;background:#fff;border:1px solid #e4e4e7;border-radius:16px;box-shadow:0 10px 24px rgba(0,0,0,.06);padding:20px;font-size:.85rem}
 @media print{
   body{background:#fff !important;-webkit-print-color-adjust:exact;print-color-adjust:exact}
   .no-print{display:none !important}
@@ -15,23 +15,33 @@ body{color:#0a0a0a;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:gr
 }
 
 .report-header{display:grid;grid-template-columns:72px 1fr;grid-gap:12px;align-items:center;margin-bottom:12px}
-.report-logo{width:72px;height:72px;border-radius:50%;object-fit:contain;border:1px solid #d4d4d8;background:#fff}
-.report-title{font-size:1.125rem;font-weight:700;text-align:center}
-.report-subtitle{font-size:.9rem;color:#52525b;text-align:center}
+.report-logo{width:72px;height:72px;border-radius:50%;object-fit:contain;border:1px solid #d4d4d8;background:#fff;padding:8px}
+.report-title{font-size:1rem;font-weight:700;text-align:center}
+.report-author{font-size:.82rem;font-weight:600;letter-spacing:.12em;text-align:center;margin-top:2px}
+.report-subtitle{font-size:.75rem;color:#52525b;text-align:center}
 
 .report-meta{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.5rem;margin:12px 0 16px 0}
 .report-meta .box{border:1px solid #e4e4e7;border-radius:12px;padding:8px 10px;background:#fafafa}
-.report-meta .label{font-size:.75rem;color:#52525b}
-.report-meta .value{font-weight:600}
+.report-meta .label{font-size:.65rem;color:#52525b}
+.report-meta .value{font-weight:600;font-size:.85rem}
 
 .report-section{margin-top:12px}
-.report-section-title{font-weight:700;margin-bottom:6px}
+.report-section-title{font-weight:700;margin-bottom:6px;font-size:.95rem}
 
 .report-table-wrapper{border:1px solid #d4d4d8;border-radius:12px;overflow:hidden}
-.report-table{width:100%;border-collapse:collapse;font-size:.9rem}
-.report-table th,.report-table td{border-bottom:1px solid #e4e4e7;padding:8px 10px}
+.report-table{width:100%;border-collapse:collapse;font-size:.8rem}
+.report-table th,.report-table td{border-bottom:1px solid #e4e4e7;padding:6px 8px}
 .report-table thead th{background:#f1f5f9;font-weight:700}
 .report-table tbody tr:last-child td{border-bottom:none}
 .right{text-align:right}
 
 .obs-col{width:38ch;max-width:38ch;white-space:normal;overflow-wrap:anywhere;word-break:break-word;hyphens:auto}
+.obs-col-header{font-size:.75rem}
+.obs-col-cell{font-size:.72rem;line-height:1.3}
+
+.report-notes-box{border:1px solid #d4d4d8;border-radius:12px;padding:8px 12px;background:#f8fafc;font-size:.78rem;min-height:96px}
+.report-notes-box ul{margin:0;padding-left:1.25rem;list-style:disc;display:grid;gap:4px}
+.report-notes-placeholder{min-height:72px}
+
+.report-footer{margin-top:10px;font-size:.63rem;color:#94a3b8;text-align:center}
+.report-footer p{margin-bottom:4px}


### PR DESCRIPTION
## Summary
- add a consolidated-only PDF export mode with a dedicated trigger for procedure-only reports
- hide daily and equivalence tables when producing consolidated exports and retitle the consolidated section for clarity
- omit the Observações finais section entirely when there are no notes to display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5658d4604832ca708f3b3b8965127