### PR TITLE
Fix TypeScript build failure for SVG logo import

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.svg" {
+  const content: string;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "Bundler",
+    "allowArbitraryExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- add Vite environment declarations so SVG imports resolve during type checking
- enable TypeScript's allowArbitraryExtensions option to allow bundler-managed assets

## Testing
- npm run build
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e5d8f088e0832ca4ad5bf9ba446af7